### PR TITLE
adding a download gif to help

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ We hope that by posting this data openly, it can not only be useful to the publi
 
 The datasets can be downloaded in CSV format from GitHub here: https://github.com/sparcopen/open-education-state-policy-tracking
 
+![download help](http://g.recordit.co/h8DxZCWvQF.gif)
+
 The files use UTF8 encoding, comma as field delimiter, quotation marks as text delimiter, and no byte order mark.
 
 ## License and Requests


### PR DESCRIPTION
Hey Nicole! I noticed that the readme link to download just pointed to the main sparc org so tried to make a pull request to fix it - but I ended up just accidentally merging it (not totally sure how). Then, I realised even the link I gave was wrong (as downloads don't work from the actual files on Github, they work at a repo level) so I added a link purely back to this repo. 

So, once I was done derping I thought a gif might be helpful to show people how to get the file. This time I actually did manage to make a pull request as originally planned for you to review! 